### PR TITLE
Provide compatibility with PHP 8.1 (#290)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   verification:
     name: "Verification tests"
-    runs-on: "ubuntu-16.04"
+    runs-on: "ubuntu-18.04"
 
     steps:
       - name: "Checkout"
@@ -80,12 +80,11 @@ jobs:
         os:
           - "ubuntu-18.04"
         php-version:
-          - "7.0"
-          - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
         mongodb-version:
           - "4.4"
         driver-version:
@@ -94,10 +93,20 @@ jobs:
           - "normal"
         include:
           - deps: "low"
-            os: "ubuntu-16.04"
+            os: "ubuntu-18.04"
             php-version: "5.6"
             mongodb-version: "3.0"
             driver-version: "1.2.0"
+          - deps: "normal"
+            os: "ubuntu-18.04"
+            php-version: "7.0"
+            mongodb-version: "4.4"
+            driver-version: "1.9.2"
+          - deps: "normal"
+            os: "ubuntu-18.04"
+            php-version: "7.1"
+            mongodb-version: "4.4"
+            driver-version: "1.11.1"
 
     steps:
       - name: "Checkout"

--- a/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
+++ b/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
@@ -18,6 +18,7 @@ namespace Alcaeus\MongoDbAdapter;
 use Alcaeus\MongoDbAdapter\Helper\ReadPreference;
 use MongoDB\Collection;
 use MongoDB\Driver\Cursor;
+use ReturnTypeWillChange;
 
 /**
  * @internal
@@ -136,6 +137,7 @@ abstract class AbstractCursor
      * @link http://www.php.net/manual/en/mongocursor.current.php
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->current;
@@ -146,6 +148,7 @@ abstract class AbstractCursor
      * @link http://www.php.net/manual/en/mongocursor.key.php
      * @return string The current result's _id as a string.
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->key;
@@ -158,6 +161,7 @@ abstract class AbstractCursor
      * @throws \MongoCursorTimeoutException
      * @return array Returns the next object
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         if (! $this->startedIterating) {
@@ -181,6 +185,7 @@ abstract class AbstractCursor
      * @throws \MongoCursorTimeoutException
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         // We can recreate the cursor to allow it to be rewound
@@ -196,6 +201,7 @@ abstract class AbstractCursor
      * @link http://www.php.net/manual/en/mongocursor.valid.php
      * @return boolean If the current result is not null.
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->valid;

--- a/lib/Alcaeus/MongoDbAdapter/CursorIterator.php
+++ b/lib/Alcaeus/MongoDbAdapter/CursorIterator.php
@@ -5,6 +5,7 @@ namespace Alcaeus\MongoDbAdapter;
 use IteratorIterator;
 use MongoDB\BSON\ObjectID;
 use Traversable;
+use ReturnTypeWillChange;
 
 /**
  * @internal
@@ -21,6 +22,7 @@ final class CursorIterator extends IteratorIterator
         $this->useIdAsKey = $useIdAsKey;
     }
 
+    #[ReturnTypeWillChange]
     public function key()
     {
         if (!$this->useIdAsKey) {

--- a/lib/Mongo/MongoClient.php
+++ b/lib/Mongo/MongoClient.php
@@ -365,7 +365,12 @@ class MongoClient
      */
     private function extractUrlOptions($server)
     {
-        $queryOptions = explode('&', parse_url($server, PHP_URL_QUERY));
+        $queryOptions = parse_url($server, PHP_URL_QUERY);
+        if (!$queryOptions) {
+            return [];
+        }
+
+        $queryOptions = explode('&', $queryOptions);
 
         $options = [];
         foreach ($queryOptions as $option) {

--- a/lib/Mongo/MongoCursor.php
+++ b/lib/Mongo/MongoCursor.php
@@ -22,7 +22,6 @@ use Alcaeus\MongoDbAdapter\CursorIterator;
 use Alcaeus\MongoDbAdapter\TypeConverter;
 use Alcaeus\MongoDbAdapter\ExceptionConverter;
 use MongoDB\Driver\Cursor;
-use MongoDB\Driver\ReadPreference;
 use MongoDB\Operation\Find;
 
 /**
@@ -134,6 +133,7 @@ class MongoCursor extends AbstractCursor implements Iterator, Countable, MongoCu
      * @param bool $foundOnly Send cursor limit and skip information to the count function, if applicable.
      * @return int The number of documents returned by this cursor's query.
      */
+    #[\ReturnTypeWillChange]
     public function count($foundOnly = false)
     {
         $optionNames = ['hint', 'maxTimeMS'];

--- a/lib/Mongo/MongoId.php
+++ b/lib/Mongo/MongoId.php
@@ -202,6 +202,7 @@ class MongoId implements Serializable, TypeInterface, JsonSerializable
     /**
      * @return stdClass
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $object = new stdClass();

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,7 @@
         <!-- Disable deprecation warnings -->
         <!-- php -r 'echo -1 & ~E_USER_DEPRECATED & ~E_DEPRECATED;' -->
         <ini name="error_reporting" value="-24577"/>
+        <const name="MONGODB_URI" value="mongodb://localhost:27017" />
     </php>
 
     <testsuites>
@@ -20,8 +21,4 @@
             <directory>./tests/Alcaeus/MongoDbAdapter/</directory>
         </testsuite>
     </testsuites>
-
-    <php>
-        <const name="MONGODB_URI" value="mongodb://localhost:27017" />
-    </php>
 </phpunit>


### PR DESCRIPTION
* Run tests on PHP 8.1

* Add ReturnTypeWillChange attributes where necessary

* Remove invalid use of parse_url result

* Drop ubuntu-16.04 in GitHub Actions

* Use lower driver versions on PHP < 7.2